### PR TITLE
Fix jwt-decode version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "angular-material-datepicker": "^1.0.2",
     "core-js": "^2.5.4",
     "hammerjs": "^2.0.8",
-    "jwt-decode": "^3.0.0",
+    "jwt-decode": "~3.0.0",
     "moment": "^2.22.2",
     "ng-pick-datetime": "^7.0.0",
     "ng-sidebar": "^9.0.0",


### PR DESCRIPTION
Avec node 8.9.4 et angular/cli en 6.1.5 on récupère un jwt-decode en version 3.1.2
On récupère l'erreur suivante : 
```
ERROR in node_modules/jwt-decode/index.d.ts(22,39): error TS2304: Cannot find name 'unknown'.
```
Avec la modification proposée ici jwt-decode est récupéré en 3.0.0 et pas d'erreur